### PR TITLE
retry_all view was missing a backslash

### DIFF
--- a/resweb/core.py
+++ b/resweb/core.py
@@ -110,7 +110,7 @@ def delete_all_failed():
     return redirect('/failed/')
 
 
-@app.route('/failed/retry_all')
+@app.route('/failed/retry_all/')
 @requires_auth
 def retry_failed(number=5000):
     failures = failure.all(g.pyres, 0, number)


### PR DESCRIPTION
The link that the Retry All button took you to had a leading slash, however the app was configured not to expect it.
So to make it consistent with all the other views which have leading slashes, I added it here too.
